### PR TITLE
Fix compile issue caused by the new line in \hypersetup

### DIFF
--- a/Templates/Toutes_années/[-A] Charte graphique A4/sources/advanced.params/misc.commands.tex
+++ b/Templates/Toutes_années/[-A] Charte graphique A4/sources/advanced.params/misc.commands.tex
@@ -33,7 +33,6 @@
     bookmarksopen=true,     % ouvre directement les sous-parties...
     bookmarksopenlevel=2,   % ... jusqu'au niveau 2
     bookmarksdepth=3,       % affiche seulement jusqu'au niveau 3
-
     colorlinks=false, % colorise les liens
     linkbordercolor={1 1 1},
     breaklinks=true, % permet le retour à la ligne dans les liens trop longs


### PR DESCRIPTION
The new line in \hypersetup was causing a compile error:

```
! Paragraph ended before \kv@processor@default was complete.
```